### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-sendgrid/config.go
+++ b/cmd/baton-sendgrid/config.go
@@ -28,6 +28,7 @@ var (
 	BaseURLField = field.StringField(
 		"base-url",
 		field.WithDescription("Override the SendGrid API URL (for testing)"),
+		field.WithHidden(true),
 	)
 )
 

--- a/cmd/baton-sendgrid/config.go
+++ b/cmd/baton-sendgrid/config.go
@@ -24,6 +24,11 @@ var (
 		field.WithDefaultValue(false),
 		field.WithDescription("Ignore subusers in the SendGrid account, subusers are an upgraded feature of sendgrid."),
 	)
+
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDescription("Override the SendGrid API URL (for testing)"),
+	)
 )
 
 var (
@@ -34,6 +39,7 @@ var (
 		SendGridApiKeyField,
 		SendGridRegionField,
 		IgnoreSubusers,
+		BaseURLField,
 	}
 
 	// FieldRelationships defines relationships between the fields listed in

--- a/cmd/baton-sendgrid/config.go
+++ b/cmd/baton-sendgrid/config.go
@@ -29,6 +29,7 @@ var (
 		"base-url",
 		field.WithDescription("Override the SendGrid API URL (for testing)"),
 		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
 	)
 )
 

--- a/cmd/baton-sendgrid/main.go
+++ b/cmd/baton-sendgrid/main.go
@@ -52,17 +52,22 @@ func getConnector(ctx context.Context, v *viper.Viper) (types.ConnectorServer, e
 	sendGridApyKey := v.GetString(SendGridApiKeyField.GetName())
 	sendgridRegion := v.GetString(SendGridRegionField.GetName())
 	sendgridIgnoreSubusers := v.GetBool(IgnoreSubusers.GetName())
+	baseUrlOverride := v.GetString(BaseURLField.GetName())
 
 	var baseUrl string
 
-	switch sendgridRegion {
-	case "eu":
-		baseUrl = client.SendGridEUBaseUrl
-	case "global":
-		baseUrl = client.SendGridBaseUrl
-	default:
-		baseUrl = client.SendGridBaseUrl
-		l.Warn("invalid sendgrid region, using the default global URL", zap.String("region", sendgridRegion))
+	if baseUrlOverride != "" {
+		baseUrl = baseUrlOverride
+	} else {
+		switch sendgridRegion {
+		case "eu":
+			baseUrl = client.SendGridEUBaseUrl
+		case "global":
+			baseUrl = client.SendGridBaseUrl
+		default:
+			baseUrl = client.SendGridBaseUrl
+			l.Warn("invalid sendgrid region, using the default global URL", zap.String("region", sendgridRegion))
+		}
 	}
 
 	sendGridCliet, err := client.NewClient(ctx, baseUrl, sendGridApyKey)

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -71,7 +71,7 @@ func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 		Description: "Connector syncing Sendgrid teammates to Baton.",
 		AccountCreationSchema: &v2.ConnectorAccountCreationSchema{
 			FieldMap: map[string]*v2.ConnectorAccountCreationSchema_Field{
-				"email": {
+				emailKey: {
 					DisplayName: "Email",
 					Required:    true,
 					Description: "Email address of the teammate to invite.",
@@ -81,7 +81,7 @@ func (d *Connector) Metadata(ctx context.Context) (*v2.ConnectorMetadata, error)
 					Placeholder: "teammate@example.com",
 					Order:       1,
 				},
-				"is_admin": {
+				isAdminKey: {
 					DisplayName: "Is Admin",
 					Required:    false,
 					Description: "Whether the teammate should have admin privileges. Admin teammates have full access to all permissions.",

--- a/pkg/connector/helper.go
+++ b/pkg/connector/helper.go
@@ -10,15 +10,20 @@ import (
 	rs "github.com/conductorone/baton-sdk/pkg/types/resource"
 )
 
+const (
+	emailKey   = "email"
+	isAdminKey = "is_admin"
+)
+
 func teammateResource(user *models.Teammate) (*v2.Resource, error) {
 	var userStatus = v2.UserTrait_Status_STATUS_ENABLED
 
 	profile := map[string]interface{}{
 		"username":       user.Username,
 		"user_type":      user.UserType,
-		"email":          user.Email,
+		emailKey:         user.Email,
 		"is_sso":         user.IsSso,
-		"is_admin":       user.IsAdmin,
+		isAdminKey:       user.IsAdmin,
 		"is_unified":     user.IsUnified,
 		"is_partner_sso": user.IsPartnerSso,
 	}
@@ -77,7 +82,7 @@ func subuserResource(subuser models.Subuser) (*v2.Resource, error) {
 	profile := map[string]interface{}{
 		"id":       subuser.Id,
 		"username": subuser.Username,
-		"email":    subuser.Email,
+		emailKey:   subuser.Email,
 		"disabled": subuser.Disabled,
 	}
 
@@ -118,7 +123,7 @@ func teammateInvitationResource(invitation *models.TeammateInvitation) (*v2.Reso
 	profile := map[string]interface{}{
 		"token":           invitation.Token,
 		"scopes":          scopes,
-		"is_admin":        invitation.IsAdmin,
+		isAdminKey:        invitation.IsAdmin,
 		"expiration_date": invitation.ExpirationDate,
 	}
 


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-sendgrid/config.go,cmd/baton-sendgrid/main.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-sendgrid --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.