### PR TITLE
fix: mark sendgrid-api-key as isSecret in config_schema

### DIFF
--- a/cmd/baton-sendgrid/config.go
+++ b/cmd/baton-sendgrid/config.go
@@ -10,6 +10,7 @@ var (
 		"sendgrid-api-key",
 		field.WithRequired(true),
 		field.WithDescription("API key for SendGrid service."),
+		field.WithIsSecret(true),
 	)
 
 	SendGridRegionField = field.StringField(


### PR DESCRIPTION
Marks `sendgrid-api-key` as a secret credential field. It is a required API key used to authenticate to SendGrid and was not flagged `isSecret`.

This connector defines its config in `cmd/baton-sendgrid/config.go` and does not commit a root `config_schema.json`; the schema is generated from these field definitions, so adding `field.WithIsSecret(true)` is the equivalent fix (no committed `config_schema.json` to regenerate).

> BREAKING: adding `isSecret: true` to these fields changes how existing configurations are stored. Customers with existing connector configurations will need to re-enter credentials after this change is deployed.

Audit: connector-secret-audit-phase15. Do not merge without review.