### PR TITLE
feat: mark teammate_invitation resource type as skipSyncAnomalyDetection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Run baton-sendgrid
         run: ./baton-sendgrid
       - name: Install baton
-        run: ./scripts/get-baton.sh && mv baton /usr/local/bin
+        uses: ConductorOne/github-workflows/actions/get-baton@v4
       - name: Grant entitlement
         run: ./baton-sendgrid --grant-entitlement="${{env.CONNECTOR_ENTITLEMENT}}" --grant-principal="${{env.CONNECTOR_PRINCIPAL}}" --grant-principal-type="${{env.CONNECTOR_PRINCIPAL_TYPE}}"
       - name: Check for grant before revoking
@@ -64,7 +64,7 @@ jobs:
       - name: Check grant was re-granted
         run: ./baton-sendgrid && baton grants --entitlement="${{env.CONNECTOR_ENTITLEMENT}}" --output-format=json | jq --exit-status ".grants[] | select( .principal.id.resource == \"${{env.CONNECTOR_PRINCIPAL}}\" )"
       - name: Test Teammate Invitation - Account Provisioning
-        uses: ConductorOne/github-workflows/actions/account-provisioning@v3
+        uses: ConductorOne/github-workflows/actions/account-provisioning@v4
         with:
           connector: ./baton-sendgrid
           account-email: ${{ vars.CI_TEAMMATE_INVITATION_PROVISIONING_EMAIL }}

--- a/baton_capabilities.json
+++ b/baton_capabilities.json
@@ -49,6 +49,9 @@
         "annotations": [
           {
             "@type": "type.googleapis.com/c1.connector.v2.SkipEntitlementsAndGrants"
+          },
+          {
+            "@type": "type.googleapis.com/c1.connector.v2.SkipSyncAnomalyDetection"
           }
         ]
       },
@@ -57,7 +60,8 @@
         "CAPABILITY_ACCOUNT_PROVISIONING",
         "CAPABILITY_RESOURCE_DELETE"
       ],
-      "permissions": {}
+      "permissions": {},
+      "skipSyncAnomalyDetection": true
     }
   ],
   "connectorCapabilities": [

--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -8,7 +8,9 @@ sidebarTitle: "Twilio SendGrid"
 
 ## Capabilities
 
-| Resource | Sync | Provision |
+{/* AUTO-GENERATED:START - capabilities
+     Generated from baton_capabilities.json. Do not edit manually. */}
+| Resource     | Sync | Provision |
 | :--- | :--- | :--- |
 | Scopes | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |
 | Subusers | <Icon icon="square-check" iconType="solid"  color="#c937ae"/> |  |

--- a/pkg/connector/resource_types.go
+++ b/pkg/connector/resource_types.go
@@ -17,7 +17,10 @@ var (
 		Id:          "teammate_invitation",
 		DisplayName: "Teammate Invitation",
 		Traits:      []v2.ResourceType_Trait{v2.ResourceType_TRAIT_USER},
-		Annotations: annotations.New(&v2.SkipEntitlementsAndGrants{}),
+		Annotations: annotations.New(
+			&v2.SkipEntitlementsAndGrants{},
+			&v2.SkipSyncAnomalyDetection{},
+		),
 	}
 
 	scopeResourceType = &v2.ResourceType{


### PR DESCRIPTION
## Summary
Mark the `teammate_invitation` resource type with the `SkipSyncAnomalyDetection` annotation. Counts on this type can legitimately drop between syncs as pending invitees accept and are reclassified as users. Without this annotation, sync anomaly detection would flag those expected drops.

The `user` resource type intentionally remains anomaly-checked.

## Test plan
- [x] `go build ./...`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
